### PR TITLE
**Hotfix** Setting Suffix & Prefix

### DIFF
--- a/src/main/java/com/christian34/easyprefix/commands/set/SetPrefixCommand.java
+++ b/src/main/java/com/christian34/easyprefix/commands/set/SetPrefixCommand.java
@@ -5,8 +5,6 @@ import com.christian34.easyprefix.commands.easyprefix.EasyPrefixCommand;
 import com.christian34.easyprefix.user.User;
 import com.christian34.easyprefix.user.UserPermission;
 import com.christian34.easyprefix.utils.Message;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -78,7 +76,7 @@ public class SetPrefixCommand implements Subcommand {
             if (args.size() > 2 && args.get(2).equalsIgnoreCase("submit")) {
                 user.setPrefix(null);
                 user.getPlayer().sendMessage(Message.CHAT_INPUT_PREFIX_SAVED.getText()
-                        .replace("%content%", ChatColor.translateAlternateColorCodes('§', user.getPrefix())));
+                        .replace("%content%", user.getPrefix().replace("§", "&")));
             } else {
                 user.getPlayer().spigot().sendMessage(CommandUtils.buildConfirmComponent(Message.CHAT_INPUT_PREFIX_RESET.getText()
                         .replace("%content%", input), "/ep setprefix reset submit"));
@@ -88,7 +86,7 @@ public class SetPrefixCommand implements Subcommand {
 
         if (!args.get(args.size() - 1).equalsIgnoreCase("submit")) {
             user.getPlayer().spigot().sendMessage(CommandUtils.buildConfirmComponent(Message.CHAT_INPUT_PREFIX_CONFIRM.getText()
-                    .replace("%content%", input), "/ep setprefix " + ChatColor.translateAlternateColorCodes('§', input) + " submit"));
+                    .replace("%content%", input), "/ep setprefix " + input + " submit"));
         } else {
             if (input.equals("null")) {
                 user.setPrefix(null);
@@ -97,7 +95,7 @@ public class SetPrefixCommand implements Subcommand {
             }
             user.saveData("custom_prefix_update", currentTime.toString());
             user.getPlayer().sendMessage(Message.CHAT_INPUT_PREFIX_SAVED.getText()
-                    .replace("%content%", ChatColor.translateAlternateColorCodes('§', user.getPrefix())));
+                    .replace("%content%", user.getPrefix().replace("§", "&")));
         }
     }
 

--- a/src/main/java/com/christian34/easyprefix/commands/set/SetPrefixCommand.java
+++ b/src/main/java/com/christian34/easyprefix/commands/set/SetPrefixCommand.java
@@ -5,6 +5,8 @@ import com.christian34.easyprefix.commands.easyprefix.EasyPrefixCommand;
 import com.christian34.easyprefix.user.User;
 import com.christian34.easyprefix.user.UserPermission;
 import com.christian34.easyprefix.utils.Message;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -76,7 +78,7 @@ public class SetPrefixCommand implements Subcommand {
             if (args.size() > 2 && args.get(2).equalsIgnoreCase("submit")) {
                 user.setPrefix(null);
                 user.getPlayer().sendMessage(Message.CHAT_INPUT_PREFIX_SAVED.getText()
-                        .replace("%content%", user.getPrefix().replace("§", "&")));
+                        .replace("%content%", ChatColor.translateAlternateColorCodes('§', user.getPrefix())));
             } else {
                 user.getPlayer().spigot().sendMessage(CommandUtils.buildConfirmComponent(Message.CHAT_INPUT_PREFIX_RESET.getText()
                         .replace("%content%", input), "/ep setprefix reset submit"));
@@ -86,7 +88,7 @@ public class SetPrefixCommand implements Subcommand {
 
         if (!args.get(args.size() - 1).equalsIgnoreCase("submit")) {
             user.getPlayer().spigot().sendMessage(CommandUtils.buildConfirmComponent(Message.CHAT_INPUT_PREFIX_CONFIRM.getText()
-                    .replace("%content%", input), "/ep setprefix " + input + " submit"));
+                    .replace("%content%", input), "/ep setprefix " + ChatColor.translateAlternateColorCodes('§', input) + " submit"));
         } else {
             if (input.equals("null")) {
                 user.setPrefix(null);
@@ -95,7 +97,7 @@ public class SetPrefixCommand implements Subcommand {
             }
             user.saveData("custom_prefix_update", currentTime.toString());
             user.getPlayer().sendMessage(Message.CHAT_INPUT_PREFIX_SAVED.getText()
-                    .replace("%content%", user.getPrefix().replace("§", "&")));
+                    .replace("%content%", ChatColor.translateAlternateColorCodes('§', user.getPrefix())));
         }
     }
 

--- a/src/main/java/com/christian34/easyprefix/commands/set/SetPrefixCommand.java
+++ b/src/main/java/com/christian34/easyprefix/commands/set/SetPrefixCommand.java
@@ -5,6 +5,7 @@ import com.christian34.easyprefix.commands.easyprefix.EasyPrefixCommand;
 import com.christian34.easyprefix.user.User;
 import com.christian34.easyprefix.user.UserPermission;
 import com.christian34.easyprefix.utils.Message;
+import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -76,7 +77,7 @@ public class SetPrefixCommand implements Subcommand {
             if (args.size() > 2 && args.get(2).equalsIgnoreCase("submit")) {
                 user.setPrefix(null);
                 user.getPlayer().sendMessage(Message.CHAT_INPUT_PREFIX_SAVED.getText()
-                        .replace("%content%", user.getPrefix().replace("§", "&")));
+                        .replace("%content%", ChatColor.translateAlternateColorCodes('§', user.getPrefix())));
             } else {
                 user.getPlayer().spigot().sendMessage(CommandUtils.buildConfirmComponent(Message.CHAT_INPUT_PREFIX_RESET.getText()
                         .replace("%content%", input), "/ep setprefix reset submit"));
@@ -86,7 +87,7 @@ public class SetPrefixCommand implements Subcommand {
 
         if (!args.get(args.size() - 1).equalsIgnoreCase("submit")) {
             user.getPlayer().spigot().sendMessage(CommandUtils.buildConfirmComponent(Message.CHAT_INPUT_PREFIX_CONFIRM.getText()
-                    .replace("%content%", input), "/ep setprefix " + input + " submit"));
+                    .replace("%content%", input), "/ep setprefix " + ChatColor.translateAlternateColorCodes('§', input) + " submit"));
         } else {
             if (input.equals("null")) {
                 user.setPrefix(null);
@@ -95,7 +96,7 @@ public class SetPrefixCommand implements Subcommand {
             }
             user.saveData("custom_prefix_update", currentTime.toString());
             user.getPlayer().sendMessage(Message.CHAT_INPUT_PREFIX_SAVED.getText()
-                    .replace("%content%", user.getPrefix().replace("§", "&")));
+                    .replace("%content%", ChatColor.translateAlternateColorCodes('§', user.getPrefix())));
         }
     }
 

--- a/src/main/java/com/christian34/easyprefix/commands/set/SetSuffixCommand.java
+++ b/src/main/java/com/christian34/easyprefix/commands/set/SetSuffixCommand.java
@@ -5,6 +5,7 @@ import com.christian34.easyprefix.commands.easyprefix.EasyPrefixCommand;
 import com.christian34.easyprefix.user.User;
 import com.christian34.easyprefix.user.UserPermission;
 import com.christian34.easyprefix.utils.Message;
+import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -76,7 +77,7 @@ public class SetSuffixCommand implements Subcommand {
             if (args.size() > 2 && args.get(2).equalsIgnoreCase("submit")) {
                 user.setSuffix(null);
                 user.getPlayer().sendMessage(Message.CHAT_INPUT_SUFFIX_SAVED.getText()
-                        .replace("%content%", user.getSuffix().replace("§", "&")));
+                        .replace("%content%", ChatColor.translateAlternateColorCodes('§', user.getPrefix())));
             } else {
                 user.getPlayer().spigot().sendMessage(CommandUtils.buildConfirmComponent(Message.CHAT_INPUT_SUFFIX_RESET.getText()
                         .replace("%content%", input), "/ep setsuffix reset submit"));
@@ -86,7 +87,7 @@ public class SetSuffixCommand implements Subcommand {
 
         if (!args.get(args.size() - 1).equalsIgnoreCase("submit")) {
             user.getPlayer().spigot().sendMessage(CommandUtils.buildConfirmComponent(Message.CHAT_INPUT_SUFFIX_CONFIRM.getText()
-                    .replace("%content%", input), "/ep setsuffix " + input + " submit"));
+                    .replace("%content%", input), "/ep setsuffix " + ChatColor.translateAlternateColorCodes('§', user.getPrefix()) + " submit"));
         } else {
             if (input.equals("null")) {
                 user.setSuffix(null);
@@ -95,7 +96,7 @@ public class SetSuffixCommand implements Subcommand {
             }
             user.saveData("custom_suffix_update", currentTime.toString());
             user.getPlayer().sendMessage(Message.CHAT_INPUT_SUFFIX_SAVED.getText()
-                    .replace("%content%", user.getSuffix().replace("§", "&")));
+                    .replace("%content%", ChatColor.translateAlternateColorCodes('§', user.getPrefix())));
         }
     }
 

--- a/src/main/java/com/christian34/easyprefix/commands/set/SetSuffixCommand.java
+++ b/src/main/java/com/christian34/easyprefix/commands/set/SetSuffixCommand.java
@@ -5,7 +5,6 @@ import com.christian34.easyprefix.commands.easyprefix.EasyPrefixCommand;
 import com.christian34.easyprefix.user.User;
 import com.christian34.easyprefix.user.UserPermission;
 import com.christian34.easyprefix.utils.Message;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -77,7 +76,7 @@ public class SetSuffixCommand implements Subcommand {
             if (args.size() > 2 && args.get(2).equalsIgnoreCase("submit")) {
                 user.setSuffix(null);
                 user.getPlayer().sendMessage(Message.CHAT_INPUT_SUFFIX_SAVED.getText()
-                        .replace("%content%", ChatColor.translateAlternateColorCodes('§', user.getPrefix())));
+                        .replace("%content%", user.getSuffix().replace("§", "&")));
             } else {
                 user.getPlayer().spigot().sendMessage(CommandUtils.buildConfirmComponent(Message.CHAT_INPUT_SUFFIX_RESET.getText()
                         .replace("%content%", input), "/ep setsuffix reset submit"));
@@ -87,7 +86,7 @@ public class SetSuffixCommand implements Subcommand {
 
         if (!args.get(args.size() - 1).equalsIgnoreCase("submit")) {
             user.getPlayer().spigot().sendMessage(CommandUtils.buildConfirmComponent(Message.CHAT_INPUT_SUFFIX_CONFIRM.getText()
-                    .replace("%content%", input), "/ep setsuffix " + ChatColor.translateAlternateColorCodes('§', user.getPrefix()) + " submit"));
+                    .replace("%content%", input), "/ep setsuffix " + input + " submit"));
         } else {
             if (input.equals("null")) {
                 user.setSuffix(null);
@@ -96,7 +95,7 @@ public class SetSuffixCommand implements Subcommand {
             }
             user.saveData("custom_suffix_update", currentTime.toString());
             user.getPlayer().sendMessage(Message.CHAT_INPUT_SUFFIX_SAVED.getText()
-                    .replace("%content%", ChatColor.translateAlternateColorCodes('§', user.getPrefix())));
+                    .replace("%content%", user.getSuffix().replace("§", "&")));
         }
     }
 


### PR DESCRIPTION
- Will no longer kick players for illegal characters in chat when clicking confirm. `eg: §` 